### PR TITLE
Extract issues, blockers, and pending items on brief

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+## Confirmation Behavior
+While asking yes/no confirmation on any code change, always explain:
+- What file(s) are being changed
+- What exactly is changing and why
+- What the expected outcome is
+- Any risks or side effects
+
+The goal is to understand the changes, before confirming to proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,4 +5,4 @@ While asking yes/no confirmation on any code change, always explain:
 - What the expected outcome is
 - Any risks or side effects
 
-The goal is to understand the changes, before confirming to proceed.
+This should be done file by file. The goal is to understand the change individually, before confirming to proceed.

--- a/electron/ai/config.cjs
+++ b/electron/ai/config.cjs
@@ -70,9 +70,20 @@ If there are no items, return [].
 Notes:
 ${note}`;
 
+const CLASSIFY_TEMPLATE = (question) => `You are classifying a question about meeting notes.
+Determine if this question is asking specifically about tracked items (issues, blockers, or pending tasks).
+Return ONLY a JSON object. No markdown, no code blocks, no explanation.
+The object must have:
+- "isItemQuery": boolean — true if the question is about issues, blockers, or pending items
+- "category": one of "issue", "blocker", "pending", or null — the specific category if asking about one type, null if asking about all or if not an item query
+- "scope": "all" or null — "all" if asking about all sessions, null otherwise
+
+Question: ${question}`;
+
 module.exports = {
   SUMMARY_TEMPLATE,
   ASK_TEMPLATE,
   EXTRACT_TEMPLATE,
+  CLASSIFY_TEMPLATE,
   AI_PROVIDER
 };

--- a/electron/ai/config.cjs
+++ b/electron/ai/config.cjs
@@ -70,13 +70,21 @@ If there are no items, return [].
 Notes:
 ${note}`;
 
-const CLASSIFY_TEMPLATE = (question) => `You are classifying a question about meeting notes.
+const CLASSIFY_TEMPLATE = (question, now) => `You are classifying a question about meeting notes.
 Determine if this question is asking specifically about tracked items (issues, blockers, or pending tasks).
+Today's date is ${now}.
 Return ONLY a JSON object. No markdown, no code blocks, no explanation.
 The object must have:
 - "isItemQuery": boolean — true if the question is about issues, blockers, or pending items
 - "category": one of "issue", "blocker", "pending", or null — the specific category if asking about one type, null if asking about all or if not an item query
-- "scope": one of "today", "this_week", "last_week", "this_month", "all", or null — the time range the question refers to; null means no specific time filter
+- "from": ISO 8601 date string (YYYY-MM-DD) for the start of the time range, or null if no lower bound
+- "to": ISO 8601 date string (YYYY-MM-DD) for the end of the time range (exclusive), or null if no upper bound
+
+Examples:
+- "yesterday" → from: the day before today, to: today
+- "this week" → from: Monday of the current week, to: null
+- "last month" → from: first day of last month, to: first day of this month
+- "all" or no time filter → from: null, to: null
 
 Question: ${question}`;
 

--- a/electron/ai/config.cjs
+++ b/electron/ai/config.cjs
@@ -76,7 +76,7 @@ Return ONLY a JSON object. No markdown, no code blocks, no explanation.
 The object must have:
 - "isItemQuery": boolean — true if the question is about issues, blockers, or pending items
 - "category": one of "issue", "blocker", "pending", or null — the specific category if asking about one type, null if asking about all or if not an item query
-- "scope": "all" or null — "all" if asking about all sessions, null otherwise
+- "scope": one of "today", "this_week", "last_week", "this_month", "all", or null — the time range the question refers to; null means no specific time filter
 
 Question: ${question}`;
 

--- a/electron/ai/config.cjs
+++ b/electron/ai/config.cjs
@@ -59,8 +59,20 @@ Use headings or subheadings for better readability.
 
 Question: ${question}`;
 
+const EXTRACT_TEMPLATE = (note) => `Extract all issues, blockers, and pending items from the notes below.
+Return ONLY a JSON array. No markdown, no code blocks, no explanation.
+Each item must have:
+- "category": one of "issue", "blocker", "pending"
+- "text": a short description of the item
+
+If there are no items, return [].
+
+Notes:
+${note}`;
+
 module.exports = {
   SUMMARY_TEMPLATE,
   ASK_TEMPLATE,
+  EXTRACT_TEMPLATE,
   AI_PROVIDER
 };

--- a/electron/db.cjs
+++ b/electron/db.cjs
@@ -85,8 +85,8 @@ function getItems(sessionIds, { category, from, to } = {}) {
   const params = [...sessionIds];
   let sql = `SELECT id, session_id, category, text, done, created_at FROM items WHERE session_id IN (${placeholders})`;
   if (category) { sql += ` AND category = ?`; params.push(category); }
-  if (from)     { sql += ` AND created_at >= ?`; params.push(from); }
-  if (to)       { sql += ` AND created_at < ?`; params.push(to); }
+  if (from)     { sql += ` AND date(created_at) >= date(?)`; params.push(from); }
+  if (to)       { sql += ` AND date(created_at) < date(?)`; params.push(to); }
   sql += ` ORDER BY created_at ASC`;
   return d.prepare(sql).all(...params);
 }

--- a/electron/db.cjs
+++ b/electron/db.cjs
@@ -24,7 +24,7 @@ function getDb() {
       session_id INTEGER NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
       category TEXT NOT NULL,
       text TEXT NOT NULL,
-      done INTEGER NOT NULL DEFAULT 0,
+      status INTEGER NOT NULL DEFAULT 0,
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
   `);
@@ -83,7 +83,7 @@ function getItems(sessionIds, { category, from, to } = {}) {
   const d = getDb();
   const placeholders = sessionIds.map(() => '?').join(',');
   const params = [...sessionIds];
-  let sql = `SELECT id, session_id, category, text, done, created_at FROM items WHERE session_id IN (${placeholders})`;
+  let sql = `SELECT id, session_id, category, text, status, created_at FROM items WHERE session_id IN (${placeholders})`;
   if (category) { sql += ` AND category = ?`; params.push(category); }
   if (from)     { sql += ` AND date(created_at) >= date(?)`; params.push(from); }
   if (to)       { sql += ` AND date(created_at) < date(?)`; params.push(to); }
@@ -91,8 +91,8 @@ function getItems(sessionIds, { category, from, to } = {}) {
   return d.prepare(sql).all(...params);
 }
 
-function markItemDone(itemId) {
-  getDb().prepare("UPDATE items SET done = 1 WHERE id = ?").run(itemId);
+function setItemStatus(itemId, status) {
+  getDb().prepare("UPDATE items SET status = ? WHERE id = ?").run(status, itemId);
 }
 
-module.exports = { createSession, updateSessionNote, updateSessionName, updateSummary, deleteSession, getAllSessions, replaceItems, getItems, markItemDone };
+module.exports = { createSession, updateSessionNote, updateSessionName, updateSummary, deleteSession, getAllSessions, replaceItems, getItems, setItemStatus };

--- a/electron/db.cjs
+++ b/electron/db.cjs
@@ -19,6 +19,14 @@ function getDb() {
       summary TEXT,
       session_type INTEGER NOT NULL DEFAULT 0
     );
+    CREATE TABLE IF NOT EXISTS items (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id INTEGER NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+      category TEXT NOT NULL,
+      text TEXT NOT NULL,
+      done INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
   `);
   return db;
 }
@@ -61,4 +69,26 @@ function getAllSessions() {
     .all();
 }
 
-module.exports = { createSession, updateSessionNote, updateSessionName, updateSummary, deleteSession, getAllSessions };
+function replaceItems(sessionId, items) {
+  const d = getDb();
+  d.prepare("DELETE FROM items WHERE session_id = ?").run(sessionId);
+  const insert = d.prepare("INSERT INTO items (session_id, category, text) VALUES (?, ?, ?)");
+  for (const item of items) {
+    insert.run(sessionId, item.category, item.text);
+  }
+}
+
+function getItems(sessionIds) {
+  if (!sessionIds.length) return [];
+  const d = getDb();
+  const placeholders = sessionIds.map(() => '?').join(',');
+  return d
+    .prepare(`SELECT id, session_id, category, text, done FROM items WHERE session_id IN (${placeholders}) ORDER BY created_at ASC`)
+    .all(...sessionIds);
+}
+
+function markItemDone(itemId) {
+  getDb().prepare("UPDATE items SET done = 1 WHERE id = ?").run(itemId);
+}
+
+module.exports = { createSession, updateSessionNote, updateSessionName, updateSummary, deleteSession, getAllSessions, replaceItems, getItems, markItemDone };

--- a/electron/db.cjs
+++ b/electron/db.cjs
@@ -27,6 +27,10 @@ function getDb() {
       status INTEGER NOT NULL DEFAULT 0,
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
+    CREATE TABLE IF NOT EXISTS ask_items (
+      ask_session_id INTEGER NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+      item_id INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE
+    );
   `);
   return db;
 }
@@ -95,4 +99,22 @@ function setItemStatus(itemId, status) {
   getDb().prepare("UPDATE items SET status = ? WHERE id = ?").run(status, itemId);
 }
 
-module.exports = { createSession, updateSessionNote, updateSessionName, updateSummary, deleteSession, getAllSessions, replaceItems, getItems, setItemStatus };
+function saveAskItems(askSessionId, itemIds) {
+  const d = getDb();
+  const insert = d.prepare("INSERT INTO ask_items (ask_session_id, item_id) VALUES (?, ?)");
+  for (const itemId of itemIds) {
+    insert.run(askSessionId, itemId);
+  }
+}
+
+function getItemsForAskSession(askSessionId) {
+  return getDb()
+    .prepare(`SELECT i.id, i.session_id, i.category, i.text, i.status, i.created_at
+              FROM items i
+              JOIN ask_items ai ON ai.item_id = i.id
+              WHERE ai.ask_session_id = ?
+              ORDER BY i.created_at ASC`)
+    .all(askSessionId);
+}
+
+module.exports = { createSession, updateSessionNote, updateSessionName, updateSummary, deleteSession, getAllSessions, replaceItems, getItems, setItemStatus, saveAskItems, getItemsForAskSession };

--- a/electron/db.cjs
+++ b/electron/db.cjs
@@ -78,13 +78,17 @@ function replaceItems(sessionId, items) {
   }
 }
 
-function getItems(sessionIds) {
+function getItems(sessionIds, { category, from, to } = {}) {
   if (!sessionIds.length) return [];
   const d = getDb();
   const placeholders = sessionIds.map(() => '?').join(',');
-  return d
-    .prepare(`SELECT id, session_id, category, text, done FROM items WHERE session_id IN (${placeholders}) ORDER BY created_at ASC`)
-    .all(...sessionIds);
+  const params = [...sessionIds];
+  let sql = `SELECT id, session_id, category, text, done, created_at FROM items WHERE session_id IN (${placeholders})`;
+  if (category) { sql += ` AND category = ?`; params.push(category); }
+  if (from)     { sql += ` AND created_at >= ?`; params.push(from); }
+  if (to)       { sql += ` AND created_at < ?`; params.push(to); }
+  sql += ` ORDER BY created_at ASC`;
+  return d.prepare(sql).all(...params);
 }
 
 function markItemDone(itemId) {

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,5 +1,4 @@
 const { app, BrowserWindow, ipcMain } = require("electron");
-const { startOfDay, startOfWeek, startOfMonth, subWeeks } = require("date-fns");
 
 app.setName("Briefing");
 const path = require("path");
@@ -59,9 +58,10 @@ ipcMain.handle("summarize", async (_event, notes) => {
 
 ipcMain.handle("ask", async (_event, sessionsContext, question) => {
   // Classify the question first to determine if it targets tracked items
-  let classification = { isItemQuery: false, category: null, scope: null };
+  let classification = { isItemQuery: false, category: null, from: null, to: null };
   try {
-    const classifyRaw = await ai.summarize([CLASSIFY_TEMPLATE(question)]);
+    const now = new Date().toISOString().slice(0, 10);
+    const classifyRaw = await ai.summarize([CLASSIFY_TEMPLATE(question, now)]);
     const cleaned = classifyRaw.replace(/```json|```/g, '').trim();
     const parsed = JSON.parse(cleaned);
     if (typeof parsed.isItemQuery === 'boolean') classification = parsed;
@@ -77,21 +77,13 @@ ipcMain.handle("ask", async (_event, sessionsContext, question) => {
     if (classification.category) {
       items = items.filter((i) => i.category === classification.category);
     }
-    if (classification.scope && classification.scope !== 'all') {
-      const now = new Date();
-      const scopeCutoffs = {
-        today:      [startOfDay(now),              null],
-        this_week:  [startOfWeek(now),             null],
-        last_week:  [startOfWeek(subWeeks(now, 1)), startOfWeek(now)],
-        this_month: [startOfMonth(now),            null],
-      };
-      const [from, to] = scopeCutoffs[classification.scope] ?? [null, null];
-      if (from) {
-        items = items.filter((i) => {
-          const t = new Date(i.created_at);
-          return t >= from && (to ? t < to : true);
-        });
-      }
+    const from = classification.from ? new Date(classification.from) : null;
+    const to   = classification.to   ? new Date(classification.to)   : null;
+    if (from || to) {
+      items = items.filter((i) => {
+        const t = new Date(i.created_at);
+        return (!from || t >= from) && (!to || t < to);
+      });
     }
     if (items.length === 0) return 'No items found.';
 

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -63,7 +63,7 @@ ipcMain.handle("ask", async (_event, sessionsContext, question) => {
     const classifyRaw = await ai.summarize([CLASSIFY_TEMPLATE(question)]);
     const cleaned = classifyRaw.replace(/```json|```/g, '').trim();
     const parsed = JSON.parse(cleaned);
-    if (parsed && typeof parsed === 'object') classification = parsed;
+    if (typeof parsed.isItemQuery === 'boolean') classification = parsed;
   } catch {
     // Fall through to normal ask on parse failure
   }

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -4,7 +4,7 @@ app.setName("Briefing");
 const path = require("path");
 const ai = require("./ai/index.cjs");
 const db = require("./db.cjs");
-const { ASK_TEMPLATE, EXTRACT_TEMPLATE } = require("./ai/config.cjs");
+const { ASK_TEMPLATE, EXTRACT_TEMPLATE, CLASSIFY_TEMPLATE } = require("./ai/config.cjs");
 
 let mainWindow;
 let expanded = false;
@@ -57,6 +57,41 @@ ipcMain.handle("summarize", async (_event, notes) => {
 });
 
 ipcMain.handle("ask", async (_event, sessionsContext, question) => {
+  // Classify the question first to determine if it targets tracked items
+  let classification = { isItemQuery: false, category: null, scope: null };
+  try {
+    const classifyRaw = await ai.summarize([CLASSIFY_TEMPLATE(question)]);
+    const cleaned = classifyRaw.replace(/```json|```/g, '').trim();
+    const parsed = JSON.parse(cleaned);
+    if (typeof parsed.isItemQuery === 'boolean') classification = parsed;
+  } catch {
+    // Fall through to normal ask on parse failure
+  }
+
+  if (classification.isItemQuery) {
+    const sessionIds = db.getAllSessions()
+      .filter((s) => s.session_type === 0)
+      .map((s) => s.id);
+    let items = db.getItems(sessionIds);
+    if (classification.category) {
+      items = items.filter((i) => i.category === classification.category);
+    }
+    if (items.length === 0) return 'No items found.';
+
+    const grouped = {};
+    for (const item of items) {
+      if (!grouped[item.category]) grouped[item.category] = [];
+      grouped[item.category].push(item);
+    }
+    return Object.entries(grouped)
+      .map(([cat, catItems]) => {
+        const heading = `## ${cat.charAt(0).toUpperCase() + cat.slice(1)}s`;
+        const lines = catItems.map((i) => `- ${i.done ? `~~${i.text}~~` : i.text}`);
+        return [heading, ...lines].join('\n');
+      })
+      .join('\n\n');
+  }
+
   const prompt = ASK_TEMPLATE(sessionsContext, question);
   return ai.summarize([prompt]);
 });

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -73,25 +73,12 @@ ipcMain.handle("ask", async (_event, sessionsContext, question) => {
     const sessionIds = db.getAllSessions()
       .filter((s) => s.session_type === 0)
       .map((s) => s.id);
-    let items = db.getItems(sessionIds, {
+    const items = db.getItems(sessionIds, {
       category: classification.category || undefined,
       from: classification.from || undefined,
       to: classification.to || undefined,
     });
-    if (items.length === 0) return 'No items found.';
-
-    const grouped = {};
-    for (const item of items) {
-      if (!grouped[item.category]) grouped[item.category] = [];
-      grouped[item.category].push(item);
-    }
-    return Object.entries(grouped)
-      .map(([cat, catItems]) => {
-        const heading = `## ${cat.charAt(0).toUpperCase() + cat.slice(1)}s`;
-        const lines = catItems.map((i) => `- ${i.done ? `~~${i.text}~~` : i.text}`);
-        return [heading, ...lines].join('\n');
-      })
-      .join('\n\n');
+    return JSON.stringify({ __itemResult: true, items });
   }
 
   const prompt = ASK_TEMPLATE(sessionsContext, question);
@@ -117,8 +104,8 @@ ipcMain.handle("db:get-items", (_event, sessionIds) => {
   return db.getItems(sessionIds);
 });
 
-ipcMain.handle("db:mark-item-done", (_event, itemId) => {
-  db.markItemDone(itemId);
+ipcMain.handle("db:set-item-status", (_event, itemId, status) => {
+  db.setItemStatus(itemId, status);
 });
 
 ipcMain.handle("toggle-expand", () => {

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -78,7 +78,7 @@ ipcMain.handle("ask", async (_event, sessionsContext, question) => {
       from: classification.from || undefined,
       to: classification.to || undefined,
     });
-    return JSON.stringify({ __itemResult: true, items });
+    return JSON.stringify({ __itemResult: true, items, category: classification.category, from: classification.from, to: classification.to });
   }
 
   const prompt = ASK_TEMPLATE(sessionsContext, question);
@@ -104,8 +104,23 @@ ipcMain.handle("db:get-items", (_event, sessionIds) => {
   return db.getItems(sessionIds);
 });
 
+ipcMain.handle("db:query-items", (_event, { category, from, to } = {}) => {
+  const sessionIds = db.getAllSessions()
+    .filter((s) => s.session_type === 0)
+    .map((s) => s.id);
+  return db.getItems(sessionIds, { category, from, to });
+});
+
 ipcMain.handle("db:set-item-status", (_event, itemId, status) => {
   db.setItemStatus(itemId, status);
+});
+
+ipcMain.handle("db:save-ask-items", (_event, askSessionId, itemIds) => {
+  db.saveAskItems(askSessionId, itemIds);
+});
+
+ipcMain.handle("db:get-items-for-ask-session", (_event, askSessionId) => {
+  return db.getItemsForAskSession(askSessionId);
 });
 
 ipcMain.handle("toggle-expand", () => {

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -63,7 +63,7 @@ ipcMain.handle("ask", async (_event, sessionsContext, question) => {
     const classifyRaw = await ai.summarize([CLASSIFY_TEMPLATE(question)]);
     const cleaned = classifyRaw.replace(/```json|```/g, '').trim();
     const parsed = JSON.parse(cleaned);
-    if (typeof parsed.isItemQuery === 'boolean') classification = parsed;
+    if (parsed && typeof parsed === 'object') classification = parsed;
   } catch {
     // Fall through to normal ask on parse failure
   }

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,4 +1,5 @@
 const { app, BrowserWindow, ipcMain } = require("electron");
+const { startOfDay, startOfWeek, startOfMonth, subWeeks } = require("date-fns");
 
 app.setName("Briefing");
 const path = require("path");
@@ -78,37 +79,19 @@ ipcMain.handle("ask", async (_event, sessionsContext, question) => {
     }
     if (classification.scope && classification.scope !== 'all') {
       const now = new Date();
-      let cutoff;
-      switch (classification.scope) {
-        case 'today':
-          cutoff = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-          break;
-        case 'this_week': {
-          const d = new Date(now);
-          d.setDate(now.getDate() - now.getDay());
-          d.setHours(0, 0, 0, 0);
-          cutoff = d;
-          break;
-        }
-        case 'last_week': {
-          const d = new Date(now);
-          d.setDate(now.getDate() - now.getDay() - 7);
-          d.setHours(0, 0, 0, 0);
-          cutoff = d;
-          const end = new Date(d);
-          end.setDate(d.getDate() + 7);
-          items = items.filter((i) => {
-            const t = new Date(i.created_at);
-            return t >= cutoff && t < end;
-          });
-          cutoff = null;
-          break;
-        }
-        case 'this_month':
-          cutoff = new Date(now.getFullYear(), now.getMonth(), 1);
-          break;
+      const scopeCutoffs = {
+        today:      [startOfDay(now),              null],
+        this_week:  [startOfWeek(now),             null],
+        last_week:  [startOfWeek(subWeeks(now, 1)), startOfWeek(now)],
+        this_month: [startOfMonth(now),            null],
+      };
+      const [from, to] = scopeCutoffs[classification.scope] ?? [null, null];
+      if (from) {
+        items = items.filter((i) => {
+          const t = new Date(i.created_at);
+          return t >= from && (to ? t < to : true);
+        });
       }
-      if (cutoff) items = items.filter((i) => new Date(i.created_at) >= cutoff);
     }
     if (items.length === 0) return 'No items found.';
 

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -73,18 +73,11 @@ ipcMain.handle("ask", async (_event, sessionsContext, question) => {
     const sessionIds = db.getAllSessions()
       .filter((s) => s.session_type === 0)
       .map((s) => s.id);
-    let items = db.getItems(sessionIds);
-    if (classification.category) {
-      items = items.filter((i) => i.category === classification.category);
-    }
-    const from = classification.from ? new Date(classification.from) : null;
-    const to   = classification.to   ? new Date(classification.to)   : null;
-    if (from || to) {
-      items = items.filter((i) => {
-        const t = new Date(i.created_at);
-        return (!from || t >= from) && (!to || t < to);
-      });
-    }
+    let items = db.getItems(sessionIds, {
+      category: classification.category || undefined,
+      from: classification.from || undefined,
+      to: classification.to || undefined,
+    });
     if (items.length === 0) return 'No items found.';
 
     const grouped = {};

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -76,6 +76,40 @@ ipcMain.handle("ask", async (_event, sessionsContext, question) => {
     if (classification.category) {
       items = items.filter((i) => i.category === classification.category);
     }
+    if (classification.scope && classification.scope !== 'all') {
+      const now = new Date();
+      let cutoff;
+      switch (classification.scope) {
+        case 'today':
+          cutoff = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+          break;
+        case 'this_week': {
+          const d = new Date(now);
+          d.setDate(now.getDate() - now.getDay());
+          d.setHours(0, 0, 0, 0);
+          cutoff = d;
+          break;
+        }
+        case 'last_week': {
+          const d = new Date(now);
+          d.setDate(now.getDate() - now.getDay() - 7);
+          d.setHours(0, 0, 0, 0);
+          cutoff = d;
+          const end = new Date(d);
+          end.setDate(d.getDate() + 7);
+          items = items.filter((i) => {
+            const t = new Date(i.created_at);
+            return t >= cutoff && t < end;
+          });
+          cutoff = null;
+          break;
+        }
+        case 'this_month':
+          cutoff = new Date(now.getFullYear(), now.getMonth(), 1);
+          break;
+      }
+      if (cutoff) items = items.filter((i) => new Date(i.created_at) >= cutoff);
+    }
     if (items.length === 0) return 'No items found.';
 
     const grouped = {};

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -4,7 +4,7 @@ app.setName("Briefing");
 const path = require("path");
 const ai = require("./ai/index.cjs");
 const db = require("./db.cjs");
-const { ASK_TEMPLATE } = require("./ai/config.cjs");
+const { ASK_TEMPLATE, EXTRACT_TEMPLATE } = require("./ai/config.cjs");
 
 let mainWindow;
 let expanded = false;
@@ -59,6 +59,29 @@ ipcMain.handle("summarize", async (_event, notes) => {
 ipcMain.handle("ask", async (_event, sessionsContext, question) => {
   const prompt = ASK_TEMPLATE(sessionsContext, question);
   return ai.summarize([prompt]);
+});
+
+ipcMain.handle("extract-items", async (_event, sessionId, note) => {
+  const prompt = EXTRACT_TEMPLATE(note);
+  const raw = await ai.summarize([prompt]);
+  let items = [];
+  try {
+    const cleaned = raw.replace(/```json|```/g, '').trim();
+    items = JSON.parse(cleaned);
+    if (!Array.isArray(items)) items = [];
+  } catch {
+    return [];
+  }
+  db.replaceItems(sessionId, items);
+  return items;
+});
+
+ipcMain.handle("db:get-items", (_event, sessionIds) => {
+  return db.getItems(sessionIds);
+});
+
+ipcMain.handle("db:mark-item-done", (_event, itemId) => {
+  db.markItemDone(itemId);
 });
 
 ipcMain.handle("toggle-expand", () => {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -13,5 +13,5 @@ contextBridge.exposeInMainWorld("electronAPI", {
   deleteSession: (sessionId) => ipcRenderer.invoke("db:delete-session", sessionId),
   extractItems: (sessionId, note) => ipcRenderer.invoke("extract-items", sessionId, note),
   getItems: (sessionIds) => ipcRenderer.invoke("db:get-items", sessionIds),
-  markItemDone: (itemId) => ipcRenderer.invoke("db:mark-item-done", itemId),
+  setItemStatus: (itemId, status) => ipcRenderer.invoke("db:set-item-status", itemId, status),
 });

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -13,5 +13,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
   deleteSession: (sessionId) => ipcRenderer.invoke("db:delete-session", sessionId),
   extractItems: (sessionId, note) => ipcRenderer.invoke("extract-items", sessionId, note),
   getItems: (sessionIds) => ipcRenderer.invoke("db:get-items", sessionIds),
+  queryItems: (filters) => ipcRenderer.invoke("db:query-items", filters),
   setItemStatus: (itemId, status) => ipcRenderer.invoke("db:set-item-status", itemId, status),
+  saveAskItems: (askSessionId, itemIds) => ipcRenderer.invoke("db:save-ask-items", askSessionId, itemIds),
+  getItemsForAskSession: (askSessionId) => ipcRenderer.invoke("db:get-items-for-ask-session", askSessionId),
 });

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -11,4 +11,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   updateSessionName: (sessionId, name) => ipcRenderer.invoke("db:update-session-name", sessionId, name),
   updateSummary: (sessionId, summary) => ipcRenderer.invoke("db:update-summary", sessionId, summary),
   deleteSession: (sessionId) => ipcRenderer.invoke("db:delete-session", sessionId),
+  extractItems: (sessionId, note) => ipcRenderer.invoke("extract-items", sessionId, note),
+  getItems: (sessionIds) => ipcRenderer.invoke("db:get-items", sessionIds),
+  markItemDone: (itemId) => ipcRenderer.invoke("db:mark-item-done", itemId),
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "dependencies": {
         "better-sqlite3": "^12.6.2",
-        "date-fns": "^4.1.0",
         "dotenv": "^17.3.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -2246,16 +2245,6 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
-    },
-    "node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
-  "name": "leader-notes",
+  "name": "briefing",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "leader-notes",
+      "name": "briefing",
       "version": "0.0.0",
       "dependencies": {
         "better-sqlite3": "^12.6.2",
+        "date-fns": "^4.1.0",
         "dotenv": "^17.3.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -2245,6 +2246,16 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "better-sqlite3": "^12.6.2",
-    "date-fns": "^4.1.0",
     "dotenv": "^17.3.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "better-sqlite3": "^12.6.2",
+    "date-fns": "^4.1.0",
     "dotenv": "^17.3.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/src/App.css
+++ b/src/App.css
@@ -606,6 +606,10 @@
 
 /* ── items section ── */
 .items-section {
+  margin-top: 0;
+}
+
+.items-section--with-summary {
   margin-top: 1.25rem;
   padding-top: 1rem;
   border-top: 1px solid rgba(0, 0, 0, 0.07);
@@ -625,19 +629,68 @@
 }
 
 .items-list {
-  list-style: disc;
-  padding-left: 1.25rem;
+  list-style: none;
+  padding: 0;
   margin: 0;
 }
 
 .items-list__item {
-  padding: 0.15rem 0;
+  display: flex;
+  flex-direction: column;
+  padding: 0.35rem 0;
   font-size: 0.85rem;
   color: #4a4a4a;
   line-height: 1.5;
 }
 
-.items-list__item--done {
+.items-list__item-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.items-list__item--done .items-list__item-text {
   text-decoration: line-through;
   color: rgba(0, 0, 0, 0.3);
+}
+
+.items-list__item-dismiss {
+  opacity: 0;
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  border: none;
+  background: transparent;
+  color: rgba(0, 0, 0, 0.35);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 0.15rem;
+  transition: opacity 0.12s ease, color 0.12s ease;
+}
+
+.items-list__item:hover .items-list__item-dismiss {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.items-list__item-dismiss:hover {
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.items-list__item-source {
+  margin-left: 1.75rem;
+  padding: 0;
+  border: none;
+  background: transparent;
+  font-size: 0.72rem;
+  font-family: inherit;
+  color: rgba(0, 0, 0, 0.35);
+  cursor: pointer;
+  text-align: left;
+}
+
+.items-list__item-source:hover {
+  color: rgba(0, 0, 0, 0.65);
+  text-decoration: underline;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -603,3 +603,41 @@
   border-left: 3px solid rgba(0, 0, 0, 0.12);
   color: rgba(0, 0, 0, 0.55);
 }
+
+/* ── items section ── */
+.items-section {
+  margin-top: 1.25rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(0, 0, 0, 0.07);
+}
+
+.items-group {
+  margin-bottom: 0.75rem;
+}
+
+.items-group__label {
+  margin: 0 0 0.3rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(0, 0, 0, 0.35);
+}
+
+.items-list {
+  list-style: disc;
+  padding-left: 1.25rem;
+  margin: 0;
+}
+
+.items-list__item {
+  padding: 0.15rem 0;
+  font-size: 0.85rem;
+  color: #4a4a4a;
+  line-height: 1.5;
+}
+
+.items-list__item--done {
+  text-decoration: line-through;
+  color: rgba(0, 0, 0, 0.3);
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,7 @@ function App() {
   const [loading, setLoading] = useState(false)
   const [askQuestion, setAskQuestion] = useState('')
   const [askOpen, setAskOpen] = useState(false)
+  const [itemsBySessionId, setItemsBySessionId] = useState({})
   const [openSessionMenuId, setOpenSessionMenuId] = useState(null)
   const [editingSessionId, setEditingSessionId] = useState(null)
   const [editingSessionName, setEditingSessionName] = useState('')
@@ -34,6 +35,18 @@ function App() {
         if (s.summary) withSummary[s.id] = s.summary
       })
       setSummariesBySessionId(withSummary)
+
+      const sessionIds = loaded.map((s) => s.id)
+      if (sessionIds.length > 0) {
+        window.electronAPI.getItems(sessionIds).then((allItems) => {
+          const grouped = {}
+          for (const item of allItems) {
+            if (!grouped[item.session_id]) grouped[item.session_id] = []
+            grouped[item.session_id].push(item)
+          }
+          setItemsBySessionId(grouped)
+        })
+      }
     })
   }, [])
 
@@ -99,12 +112,10 @@ function App() {
       const result = await window.electronAPI.summarize(notesToSend)
       setSummariesBySessionId((prev) => ({ ...prev, [sessionId]: result }))
       await window.electronAPI.updateSummary(sessionId, result)
-      const items = await window.electronAPI.extractItems(sessionId, noteToSave)
-      if (Array.isArray(items) && items.length > 0) {
-        setSummariesBySessionId((prev) => ({
-          ...prev,
-          [sessionId]: result + '\n\n```json\n' + JSON.stringify(items, null, 2) + '\n```'
-        }))
+      await window.electronAPI.extractItems(sessionId, noteToSave)
+      const items = await window.electronAPI.getItems([sessionId])
+      if (items.length > 0) {
+        setItemsBySessionId((prev) => ({ ...prev, [sessionId]: items }))
       }
     } catch (err) {
       setSummariesBySessionId((prev) => ({ ...prev, [sessionId]: `Error: ${err.message}` }))
@@ -414,6 +425,7 @@ function App() {
         {expanded && (() => {
           const sessionIdToShow = selectedSessionId ?? currentSession?.id ?? null
           const summaryToShow = sessionIdToShow ? summariesBySessionId[sessionIdToShow] : null
+          const itemsToShow = sessionIdToShow ? (itemsBySessionId[sessionIdToShow] ?? []) : []
           return (
             <div className="summary-panel">
               {askOpen ? (
@@ -448,6 +460,27 @@ function App() {
                 <p className="summary-empty">No summary for this session yet</p>
               ) : (
                 <p className="summary-empty">Submit a note to see the brief</p>
+              )}
+              {itemsToShow.length > 0 && (
+                <div className="items-section">
+                  <h3>Items</h3>
+                  {['issue', 'blocker', 'pending'].map((cat) => {
+                    const catItems = itemsToShow.filter((i) => i.category === cat)
+                    if (!catItems.length) return null
+                    return (
+                      <div key={cat} className="items-group">
+                        <p className="items-group__label">{cat}s</p>
+                        <ul className="items-list">
+                          {catItems.map((item) => (
+                            <li key={item.id} className={`items-list__item${item.done ? ' items-list__item--done' : ''}`}>
+                              {item.text}
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )
+                  })}
+                </div>
               )}
             </div>
           )

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,7 +28,7 @@ function App() {
   const [editingSessionSource, setEditingSessionSource] = useState(null)
 
   useEffect(() => {
-    window.electronAPI.getSessions().then((loaded) => {
+    window.electronAPI.getSessions().then(async (loaded) => {
       setSessions(loaded)
       const withSummary = {}
       loaded.forEach((s) => {
@@ -36,17 +36,24 @@ function App() {
       })
       setSummariesBySessionId(withSummary)
 
-      const sessionIds = loaded.map((s) => s.id)
-      if (sessionIds.length > 0) {
-        window.electronAPI.getItems(sessionIds).then((allItems) => {
-          const grouped = {}
-          for (const item of allItems) {
-            if (!grouped[item.session_id]) grouped[item.session_id] = []
-            grouped[item.session_id].push(item)
-          }
-          setItemsBySessionId(grouped)
-        })
+      const noteSessions = loaded.filter((s) => s.session_type === SessionType.NOTE)
+      const askSessions = loaded.filter((s) => s.session_type === SessionType.ASK)
+      const grouped = {}
+
+      if (noteSessions.length > 0) {
+        const allItems = await window.electronAPI.getItems(noteSessions.map((s) => s.id))
+        for (const item of allItems) {
+          if (!grouped[item.session_id]) grouped[item.session_id] = []
+          grouped[item.session_id].push(item)
+        }
       }
+
+      await Promise.all(askSessions.map(async (s) => {
+        const items = await window.electronAPI.getItemsForAskSession(s.id)
+        if (items.length > 0) grouped[s.id] = items
+      }))
+
+      setItemsBySessionId(grouped)
     })
   }, [])
 
@@ -183,7 +190,7 @@ function App() {
         const parsed = JSON.parse(result)
         if (parsed.__itemResult) {
           askItems = parsed.items
-          summary = ''
+          summary = null
         }
       } catch {
         // normal text answer
@@ -198,6 +205,7 @@ function App() {
       ])
       setSummariesBySessionId((prev) => ({ ...prev, [sessionId]: summary }))
       if (askItems) {
+        await window.electronAPI.saveAskItems(sessionId, askItems.map((i) => i.id))
         setItemsBySessionId((prev) => ({ ...prev, [sessionId]: askItems }))
       }
       setActiveSessionId(null)
@@ -439,6 +447,7 @@ function App() {
         </div>
         {expanded && (() => {
           const sessionIdToShow = selectedSessionId ?? currentSession?.id ?? null
+          const sessionToShow = sessions.find((s) => s.id === sessionIdToShow) ?? null
           const summaryToShow = sessionIdToShow ? summariesBySessionId[sessionIdToShow] : null
           const itemsToShow = sessionIdToShow ? (itemsBySessionId[sessionIdToShow] ?? []) : []
           return (
@@ -474,7 +483,13 @@ function App() {
                       <Markdown>{summaryToShow}</Markdown>
                     </div>
                   ) : !itemsToShow.length && (
-                    <p className="summary-empty">{sessionIdToShow ? 'No summary for this session yet' : 'Submit a note to see the brief'}</p>
+                    <p className="summary-empty">
+                      {!sessionIdToShow
+                        ? 'Submit a note to see the brief'
+                        : sessionToShow?.session_type === SessionType.ASK
+                          ? 'No answer for this question'
+                          : 'No summary for this session yet'}
+                    </p>
                   )}
                   {itemsToShow.length > 0 && (
                     <div className={`items-section${summaryToShow ? ' items-section--with-summary' : ''}`}>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -99,6 +99,13 @@ function App() {
       const result = await window.electronAPI.summarize(notesToSend)
       setSummariesBySessionId((prev) => ({ ...prev, [sessionId]: result }))
       await window.electronAPI.updateSummary(sessionId, result)
+      const items = await window.electronAPI.extractItems(sessionId, noteToSave)
+      if (Array.isArray(items) && items.length > 0) {
+        setSummariesBySessionId((prev) => ({
+          ...prev,
+          [sessionId]: result + '\n\n```json\n' + JSON.stringify(items, null, 2) + '\n```'
+        }))
+      }
     } catch (err) {
       setSummariesBySessionId((prev) => ({ ...prev, [sessionId]: `Error: ${err.message}` }))
     } finally {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -177,14 +177,29 @@ function App() {
 
       const result = await window.electronAPI.ask(sessionsContext, questionText)
 
+      let summary = result
+      let askItems = null
+      try {
+        const parsed = JSON.parse(result)
+        if (parsed.__itemResult) {
+          askItems = parsed.items
+          summary = ''
+        }
+      } catch {
+        // normal text answer
+      }
+
       // Create a new session for this Q&A
       await window.electronAPI.createSession(sessionId, sessionName, questionText, SessionType.ASK)
-      await window.electronAPI.updateSummary(sessionId, result)
+      await window.electronAPI.updateSummary(sessionId, summary)
       setSessions((prev) => [
         ...prev,
-        { id: sessionId, name: sessionName, note: questionText, summary: result, session_type: SessionType.ASK }
+        { id: sessionId, name: sessionName, note: questionText, summary, session_type: SessionType.ASK }
       ])
-      setSummariesBySessionId((prev) => ({ ...prev, [sessionId]: result }))
+      setSummariesBySessionId((prev) => ({ ...prev, [sessionId]: summary }))
+      if (askItems) {
+        setItemsBySessionId((prev) => ({ ...prev, [sessionId]: askItems }))
+      }
       setActiveSessionId(null)
       setSelectedSessionId(sessionId)
     } catch (err) {
@@ -452,28 +467,77 @@ function App() {
               <h3>Brief</h3>
               {loading ? (
                 <p className="summary-loading">Thinking...</p>
-              ) : summaryToShow ? (
-                <div className="summary-content">
-                  <Markdown>{summaryToShow}</Markdown>
-                </div>
-              ) : sessionIdToShow ? (
-                <p className="summary-empty">No summary for this session yet</p>
               ) : (
-                <p className="summary-empty">Submit a note to see the brief</p>
-              )}
-              {itemsToShow.length > 0 && (
-                <div className="items-section">
-                  <h3>Items</h3>
-                  {['issue', 'blocker', 'pending'].map((cat) => {
-                    const catItems = itemsToShow.filter((i) => i.category === cat)
+                <>
+                  {summaryToShow ? (
+                    <div className="summary-content">
+                      <Markdown>{summaryToShow}</Markdown>
+                    </div>
+                  ) : !itemsToShow.length && (
+                    <p className="summary-empty">{sessionIdToShow ? 'No summary for this session yet' : 'Submit a note to see the brief'}</p>
+                  )}
+                  {itemsToShow.length > 0 && (
+                    <div className={`items-section${summaryToShow ? ' items-section--with-summary' : ''}`}>
+                      {['issue', 'blocker', 'pending'].map((cat) => {
+                    const catItems = itemsToShow.filter((i) => i.category === cat && i.status !== -1)
                     if (!catItems.length) return null
                     return (
                       <div key={cat} className="items-group">
                         <p className="items-group__label">{cat}s</p>
                         <ul className="items-list">
                           {catItems.map((item) => (
-                            <li key={item.id} className={`items-list__item${item.done ? ' items-list__item--done' : ''}`}>
-                              {item.text}
+                            <li key={item.id} className={`items-list__item${item.status === 1 ? ' items-list__item--done' : ''}`}>
+                              <div className="items-list__item-row">
+                              <input
+                                type="checkbox"
+                                checked={item.status === 1}
+                                onChange={() => {
+                                  const newStatus = item.status === 1 ? 0 : 1
+                                  window.electronAPI.setItemStatus(item.id, newStatus)
+                                  setItemsBySessionId((prev) => {
+                                    const result = { ...prev }
+                                    const updateSession = (sid) => {
+                                      if (result[sid]) result[sid] = result[sid].map((i) => i.id === item.id ? { ...i, status: newStatus } : i)
+                                    }
+                                    updateSession(item.session_id)
+                                    if (sessionIdToShow !== item.session_id) updateSession(sessionIdToShow)
+                                    return result
+                                  })
+                                }}
+                              />
+                              <span className="items-list__item-text"><Markdown components={{ p: ({ children }) => <>{children}</> }}>{item.text}</Markdown></span>
+                              <button
+                                type="button"
+                                className="items-list__item-dismiss"
+                                onClick={() => {
+                                  window.electronAPI.setItemStatus(item.id, -1)
+                                  setItemsBySessionId((prev) => {
+                                    const result = { ...prev }
+                                    const updateSession = (sid) => {
+                                      if (result[sid]) result[sid] = result[sid].map((i) => i.id === item.id ? { ...i, status: -1 } : i)
+                                    }
+                                    updateSession(item.session_id)
+                                    if (sessionIdToShow !== item.session_id) updateSession(sessionIdToShow)
+                                    return result
+                                  })
+                                }}
+                                aria-label="Mark as invalid"
+                              >
+                                ×
+                              </button>
+                              </div>
+                              {item.session_id !== sessionIdToShow && (() => {
+                                const source = sessions.find((s) => s.id === item.session_id)
+                                return source ? (
+                                  <button
+                                    type="button"
+                                    className="items-list__item-source"
+                                    onClick={() => handleRestoreSession(item.session_id)}
+                                  >
+                                    {source.name}
+                                  </button>
+                                ) : null
+                              })()}
                             </li>
                           ))}
                         </ul>
@@ -481,6 +545,8 @@ function App() {
                     )
                   })}
                 </div>
+              )}
+                </>
               )}
             </div>
           )


### PR DESCRIPTION
Adds automatic item extraction when a note is briefed. After the summary is generated, a second AI call parses the raw notes and extracts issues, blockers, and pending items into a new items table. Items are replaced on every re-brief. Extracted items are temporarily displayed as a JSON code block below the summary for testing.