### PR TITLE
Items query: classify, filter, and format tracked items from DB

### DIFF
--- a/electron/ai/config.cjs
+++ b/electron/ai/config.cjs
@@ -70,9 +70,20 @@ If there are no items, return [].
 Notes:
 ${note}`;
 
+const CLASSIFY_TEMPLATE = (question) => `You are classifying a question about meeting notes.
+Determine if this question is asking specifically about tracked items (issues, blockers, or pending tasks).
+Return ONLY a JSON object. No markdown, no code blocks, no explanation.
+The object must have:
+- "isItemQuery": boolean — true if the question is about issues, blockers, or pending items
+- "category": one of "issue", "blocker", "pending", or null — the specific category if asking about one type, null if asking about all or if not an item query
+- "scope": "all" or null — "all" if asking about all sessions, null otherwise
+
+Question: ${question}`;
+
 module.exports = {
   SUMMARY_TEMPLATE,
   ASK_TEMPLATE,
   EXTRACT_TEMPLATE,
+  CLASSIFY_TEMPLATE,
   AI_PROVIDER
 };

--- a/electron/ai/config.cjs
+++ b/electron/ai/config.cjs
@@ -70,13 +70,21 @@ If there are no items, return [].
 Notes:
 ${note}`;
 
-const CLASSIFY_TEMPLATE = (question) => `You are classifying a question about meeting notes.
+const CLASSIFY_TEMPLATE = (question, now) => `You are classifying a question about meeting notes.
 Determine if this question is asking specifically about tracked items (issues, blockers, or pending tasks).
+Today's date is ${now}.
 Return ONLY a JSON object. No markdown, no code blocks, no explanation.
 The object must have:
 - "isItemQuery": boolean — true if the question is about issues, blockers, or pending items
 - "category": one of "issue", "blocker", "pending", or null — the specific category if asking about one type, null if asking about all or if not an item query
-- "scope": one of "today", "this_week", "last_week", "this_month", "all", or null — the time range the question refers to; null means no specific time filter
+- "from": ISO 8601 date string (YYYY-MM-DD) for the start of the time range, or null if no lower bound
+- "to": ISO 8601 date string (YYYY-MM-DD) for the end of the time range (exclusive), or null if no upper bound
+
+Examples:
+- "yesterday" → from: the day before today, to: today
+- "this week" → from: Monday of the current week, to: null
+- "last month" → from: first day of last month, to: first day of this month
+- "all" or no time filter → from: null, to: null
 
 Question: ${question}`;
 

--- a/electron/ai/config.cjs
+++ b/electron/ai/config.cjs
@@ -76,7 +76,7 @@ Return ONLY a JSON object. No markdown, no code blocks, no explanation.
 The object must have:
 - "isItemQuery": boolean — true if the question is about issues, blockers, or pending items
 - "category": one of "issue", "blocker", "pending", or null — the specific category if asking about one type, null if asking about all or if not an item query
-- "scope": "all" or null — "all" if asking about all sessions, null otherwise
+- "scope": one of "today", "this_week", "last_week", "this_month", "all", or null — the time range the question refers to; null means no specific time filter
 
 Question: ${question}`;
 

--- a/electron/db.cjs
+++ b/electron/db.cjs
@@ -85,8 +85,8 @@ function getItems(sessionIds, { category, from, to } = {}) {
   const params = [...sessionIds];
   let sql = `SELECT id, session_id, category, text, done, created_at FROM items WHERE session_id IN (${placeholders})`;
   if (category) { sql += ` AND category = ?`; params.push(category); }
-  if (from)     { sql += ` AND created_at >= ?`; params.push(from); }
-  if (to)       { sql += ` AND created_at < ?`; params.push(to); }
+  if (from)     { sql += ` AND date(created_at) >= date(?)`; params.push(from); }
+  if (to)       { sql += ` AND date(created_at) < date(?)`; params.push(to); }
   sql += ` ORDER BY created_at ASC`;
   return d.prepare(sql).all(...params);
 }

--- a/electron/db.cjs
+++ b/electron/db.cjs
@@ -78,13 +78,17 @@ function replaceItems(sessionId, items) {
   }
 }
 
-function getItems(sessionIds) {
+function getItems(sessionIds, { category, from, to } = {}) {
   if (!sessionIds.length) return [];
   const d = getDb();
   const placeholders = sessionIds.map(() => '?').join(',');
-  return d
-    .prepare(`SELECT id, session_id, category, text, done FROM items WHERE session_id IN (${placeholders}) ORDER BY created_at ASC`)
-    .all(...sessionIds);
+  const params = [...sessionIds];
+  let sql = `SELECT id, session_id, category, text, done, created_at FROM items WHERE session_id IN (${placeholders})`;
+  if (category) { sql += ` AND category = ?`; params.push(category); }
+  if (from)     { sql += ` AND created_at >= ?`; params.push(from); }
+  if (to)       { sql += ` AND created_at < ?`; params.push(to); }
+  sql += ` ORDER BY created_at ASC`;
+  return d.prepare(sql).all(...params);
 }
 
 function markItemDone(itemId) {

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,5 +1,4 @@
 const { app, BrowserWindow, ipcMain } = require("electron");
-const { startOfDay, startOfWeek, startOfMonth, subWeeks } = require("date-fns");
 
 app.setName("Briefing");
 const path = require("path");
@@ -59,9 +58,10 @@ ipcMain.handle("summarize", async (_event, notes) => {
 
 ipcMain.handle("ask", async (_event, sessionsContext, question) => {
   // Classify the question first to determine if it targets tracked items
-  let classification = { isItemQuery: false, category: null, scope: null };
+  let classification = { isItemQuery: false, category: null, from: null, to: null };
   try {
-    const classifyRaw = await ai.summarize([CLASSIFY_TEMPLATE(question)]);
+    const now = new Date().toISOString().slice(0, 10);
+    const classifyRaw = await ai.summarize([CLASSIFY_TEMPLATE(question, now)]);
     const cleaned = classifyRaw.replace(/```json|```/g, '').trim();
     const parsed = JSON.parse(cleaned);
     if (typeof parsed.isItemQuery === 'boolean') classification = parsed;
@@ -77,21 +77,13 @@ ipcMain.handle("ask", async (_event, sessionsContext, question) => {
     if (classification.category) {
       items = items.filter((i) => i.category === classification.category);
     }
-    if (classification.scope && classification.scope !== 'all') {
-      const now = new Date();
-      const scopeCutoffs = {
-        today:      [startOfDay(now),              null],
-        this_week:  [startOfWeek(now),             null],
-        last_week:  [startOfWeek(subWeeks(now, 1)), startOfWeek(now)],
-        this_month: [startOfMonth(now),            null],
-      };
-      const [from, to] = scopeCutoffs[classification.scope] ?? [null, null];
-      if (from) {
-        items = items.filter((i) => {
-          const t = new Date(i.created_at);
-          return t >= from && (to ? t < to : true);
-        });
-      }
+    const from = classification.from ? new Date(classification.from) : null;
+    const to   = classification.to   ? new Date(classification.to)   : null;
+    if (from || to) {
+      items = items.filter((i) => {
+        const t = new Date(i.created_at);
+        return (!from || t >= from) && (!to || t < to);
+      });
     }
     if (items.length === 0) return 'No items found.';
 

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -63,7 +63,7 @@ ipcMain.handle("ask", async (_event, sessionsContext, question) => {
     const classifyRaw = await ai.summarize([CLASSIFY_TEMPLATE(question)]);
     const cleaned = classifyRaw.replace(/```json|```/g, '').trim();
     const parsed = JSON.parse(cleaned);
-    if (parsed && typeof parsed === 'object') classification = parsed;
+    if (typeof parsed.isItemQuery === 'boolean') classification = parsed;
   } catch {
     // Fall through to normal ask on parse failure
   }

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -4,7 +4,7 @@ app.setName("Briefing");
 const path = require("path");
 const ai = require("./ai/index.cjs");
 const db = require("./db.cjs");
-const { ASK_TEMPLATE, EXTRACT_TEMPLATE } = require("./ai/config.cjs");
+const { ASK_TEMPLATE, EXTRACT_TEMPLATE, CLASSIFY_TEMPLATE } = require("./ai/config.cjs");
 
 let mainWindow;
 let expanded = false;
@@ -57,6 +57,41 @@ ipcMain.handle("summarize", async (_event, notes) => {
 });
 
 ipcMain.handle("ask", async (_event, sessionsContext, question) => {
+  // Classify the question first to determine if it targets tracked items
+  let classification = { isItemQuery: false, category: null, scope: null };
+  try {
+    const classifyRaw = await ai.summarize([CLASSIFY_TEMPLATE(question)]);
+    const cleaned = classifyRaw.replace(/```json|```/g, '').trim();
+    const parsed = JSON.parse(cleaned);
+    if (typeof parsed.isItemQuery === 'boolean') classification = parsed;
+  } catch {
+    // Fall through to normal ask on parse failure
+  }
+
+  if (classification.isItemQuery) {
+    const sessionIds = db.getAllSessions()
+      .filter((s) => s.session_type === 0)
+      .map((s) => s.id);
+    let items = db.getItems(sessionIds);
+    if (classification.category) {
+      items = items.filter((i) => i.category === classification.category);
+    }
+    if (items.length === 0) return 'No items found.';
+
+    const grouped = {};
+    for (const item of items) {
+      if (!grouped[item.category]) grouped[item.category] = [];
+      grouped[item.category].push(item);
+    }
+    return Object.entries(grouped)
+      .map(([cat, catItems]) => {
+        const heading = `## ${cat.charAt(0).toUpperCase() + cat.slice(1)}s`;
+        const lines = catItems.map((i) => `- ${i.done ? `~~${i.text}~~` : i.text}`);
+        return [heading, ...lines].join('\n');
+      })
+      .join('\n\n');
+  }
+
   const prompt = ASK_TEMPLATE(sessionsContext, question);
   return ai.summarize([prompt]);
 });

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -63,7 +63,7 @@ ipcMain.handle("ask", async (_event, sessionsContext, question) => {
     const classifyRaw = await ai.summarize([CLASSIFY_TEMPLATE(question)]);
     const cleaned = classifyRaw.replace(/```json|```/g, '').trim();
     const parsed = JSON.parse(cleaned);
-    if (typeof parsed.isItemQuery === 'boolean') classification = parsed;
+    if (parsed && typeof parsed === 'object') classification = parsed;
   } catch {
     // Fall through to normal ask on parse failure
   }

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,4 +1,5 @@
 const { app, BrowserWindow, ipcMain } = require("electron");
+const { startOfDay, startOfWeek, startOfMonth, subWeeks } = require("date-fns");
 
 app.setName("Briefing");
 const path = require("path");
@@ -78,37 +79,19 @@ ipcMain.handle("ask", async (_event, sessionsContext, question) => {
     }
     if (classification.scope && classification.scope !== 'all') {
       const now = new Date();
-      let cutoff;
-      switch (classification.scope) {
-        case 'today':
-          cutoff = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-          break;
-        case 'this_week': {
-          const d = new Date(now);
-          d.setDate(now.getDate() - now.getDay());
-          d.setHours(0, 0, 0, 0);
-          cutoff = d;
-          break;
-        }
-        case 'last_week': {
-          const d = new Date(now);
-          d.setDate(now.getDate() - now.getDay() - 7);
-          d.setHours(0, 0, 0, 0);
-          cutoff = d;
-          const end = new Date(d);
-          end.setDate(d.getDate() + 7);
-          items = items.filter((i) => {
-            const t = new Date(i.created_at);
-            return t >= cutoff && t < end;
-          });
-          cutoff = null;
-          break;
-        }
-        case 'this_month':
-          cutoff = new Date(now.getFullYear(), now.getMonth(), 1);
-          break;
+      const scopeCutoffs = {
+        today:      [startOfDay(now),              null],
+        this_week:  [startOfWeek(now),             null],
+        last_week:  [startOfWeek(subWeeks(now, 1)), startOfWeek(now)],
+        this_month: [startOfMonth(now),            null],
+      };
+      const [from, to] = scopeCutoffs[classification.scope] ?? [null, null];
+      if (from) {
+        items = items.filter((i) => {
+          const t = new Date(i.created_at);
+          return t >= from && (to ? t < to : true);
+        });
       }
-      if (cutoff) items = items.filter((i) => new Date(i.created_at) >= cutoff);
     }
     if (items.length === 0) return 'No items found.';
 

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -73,18 +73,11 @@ ipcMain.handle("ask", async (_event, sessionsContext, question) => {
     const sessionIds = db.getAllSessions()
       .filter((s) => s.session_type === 0)
       .map((s) => s.id);
-    let items = db.getItems(sessionIds);
-    if (classification.category) {
-      items = items.filter((i) => i.category === classification.category);
-    }
-    const from = classification.from ? new Date(classification.from) : null;
-    const to   = classification.to   ? new Date(classification.to)   : null;
-    if (from || to) {
-      items = items.filter((i) => {
-        const t = new Date(i.created_at);
-        return (!from || t >= from) && (!to || t < to);
-      });
-    }
+    let items = db.getItems(sessionIds, {
+      category: classification.category || undefined,
+      from: classification.from || undefined,
+      to: classification.to || undefined,
+    });
     if (items.length === 0) return 'No items found.';
 
     const grouped = {};

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -76,6 +76,40 @@ ipcMain.handle("ask", async (_event, sessionsContext, question) => {
     if (classification.category) {
       items = items.filter((i) => i.category === classification.category);
     }
+    if (classification.scope && classification.scope !== 'all') {
+      const now = new Date();
+      let cutoff;
+      switch (classification.scope) {
+        case 'today':
+          cutoff = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+          break;
+        case 'this_week': {
+          const d = new Date(now);
+          d.setDate(now.getDate() - now.getDay());
+          d.setHours(0, 0, 0, 0);
+          cutoff = d;
+          break;
+        }
+        case 'last_week': {
+          const d = new Date(now);
+          d.setDate(now.getDate() - now.getDay() - 7);
+          d.setHours(0, 0, 0, 0);
+          cutoff = d;
+          const end = new Date(d);
+          end.setDate(d.getDate() + 7);
+          items = items.filter((i) => {
+            const t = new Date(i.created_at);
+            return t >= cutoff && t < end;
+          });
+          cutoff = null;
+          break;
+        }
+        case 'this_month':
+          cutoff = new Date(now.getFullYear(), now.getMonth(), 1);
+          break;
+      }
+      if (cutoff) items = items.filter((i) => new Date(i.created_at) >= cutoff);
+    }
     if (items.length === 0) return 'No items found.';
 
     const grouped = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "dependencies": {
         "better-sqlite3": "^12.6.2",
-        "date-fns": "^4.1.0",
         "dotenv": "^17.3.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -2246,16 +2245,6 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
-    },
-    "node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
-  "name": "leader-notes",
+  "name": "briefing",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "leader-notes",
+      "name": "briefing",
       "version": "0.0.0",
       "dependencies": {
         "better-sqlite3": "^12.6.2",
+        "date-fns": "^4.1.0",
         "dotenv": "^17.3.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -2245,6 +2246,16 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "better-sqlite3": "^12.6.2",
-    "date-fns": "^4.1.0",
     "dotenv": "^17.3.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "better-sqlite3": "^12.6.2",
+    "date-fns": "^4.1.0",
     "dotenv": "^17.3.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",


### PR DESCRIPTION
∙	Adds isItemQuery classification to the ask handler — if the question is about tracked items, it bypasses the LLM and queries the DB directly
	∙	CLASSIFY_TEMPLATE now receives today’s date and returns concrete from/to ISO date strings, handling any natural language time expression without hardcoded scope mappings
	∙	getItems now accepts optional { category, from, to } filters applied directly in SQL — no post-fetch JS filtering
	∙	Removed date-fns dependency
Test plan:
	∙	“What are the issues this week?” → only issues within current week, no LLM call
	∙	“What are the blockers yesterday?” → correct date range resolved
	∙	“What are all pending items?” → all pending, no date filter
	∙	“What are all items?” → all categories grouped by type
	∙	General question → falls through to normal LLM flow
	∙	Item question with no results → returns “No items found.”