### PR TITLE
items panel with done/invalid status and ask integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,4 +5,4 @@ While asking yes/no confirmation on any code change, always explain:
 - What the expected outcome is
 - Any risks or side effects
 
-The goal is to understand the changes, before confirming to proceed.
+This should be done file by file. The goal is to understand the change individually, before confirming to proceed.

--- a/electron/db.cjs
+++ b/electron/db.cjs
@@ -24,7 +24,7 @@ function getDb() {
       session_id INTEGER NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
       category TEXT NOT NULL,
       text TEXT NOT NULL,
-      done INTEGER NOT NULL DEFAULT 0,
+      status INTEGER NOT NULL DEFAULT 0,
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
   `);
@@ -83,7 +83,7 @@ function getItems(sessionIds, { category, from, to } = {}) {
   const d = getDb();
   const placeholders = sessionIds.map(() => '?').join(',');
   const params = [...sessionIds];
-  let sql = `SELECT id, session_id, category, text, done, created_at FROM items WHERE session_id IN (${placeholders})`;
+  let sql = `SELECT id, session_id, category, text, status, created_at FROM items WHERE session_id IN (${placeholders})`;
   if (category) { sql += ` AND category = ?`; params.push(category); }
   if (from)     { sql += ` AND date(created_at) >= date(?)`; params.push(from); }
   if (to)       { sql += ` AND date(created_at) < date(?)`; params.push(to); }
@@ -91,8 +91,8 @@ function getItems(sessionIds, { category, from, to } = {}) {
   return d.prepare(sql).all(...params);
 }
 
-function markItemDone(itemId) {
-  getDb().prepare("UPDATE items SET done = 1 WHERE id = ?").run(itemId);
+function setItemStatus(itemId, status) {
+  getDb().prepare("UPDATE items SET status = ? WHERE id = ?").run(status, itemId);
 }
 
-module.exports = { createSession, updateSessionNote, updateSessionName, updateSummary, deleteSession, getAllSessions, replaceItems, getItems, markItemDone };
+module.exports = { createSession, updateSessionNote, updateSessionName, updateSummary, deleteSession, getAllSessions, replaceItems, getItems, setItemStatus };

--- a/electron/db.cjs
+++ b/electron/db.cjs
@@ -27,6 +27,10 @@ function getDb() {
       status INTEGER NOT NULL DEFAULT 0,
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
+    CREATE TABLE IF NOT EXISTS ask_items (
+      ask_session_id INTEGER NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+      item_id INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE
+    );
   `);
   return db;
 }
@@ -95,4 +99,22 @@ function setItemStatus(itemId, status) {
   getDb().prepare("UPDATE items SET status = ? WHERE id = ?").run(status, itemId);
 }
 
-module.exports = { createSession, updateSessionNote, updateSessionName, updateSummary, deleteSession, getAllSessions, replaceItems, getItems, setItemStatus };
+function saveAskItems(askSessionId, itemIds) {
+  const d = getDb();
+  const insert = d.prepare("INSERT INTO ask_items (ask_session_id, item_id) VALUES (?, ?)");
+  for (const itemId of itemIds) {
+    insert.run(askSessionId, itemId);
+  }
+}
+
+function getItemsForAskSession(askSessionId) {
+  return getDb()
+    .prepare(`SELECT i.id, i.session_id, i.category, i.text, i.status, i.created_at
+              FROM items i
+              JOIN ask_items ai ON ai.item_id = i.id
+              WHERE ai.ask_session_id = ?
+              ORDER BY i.created_at ASC`)
+    .all(askSessionId);
+}
+
+module.exports = { createSession, updateSessionNote, updateSessionName, updateSummary, deleteSession, getAllSessions, replaceItems, getItems, setItemStatus, saveAskItems, getItemsForAskSession };

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -73,25 +73,12 @@ ipcMain.handle("ask", async (_event, sessionsContext, question) => {
     const sessionIds = db.getAllSessions()
       .filter((s) => s.session_type === 0)
       .map((s) => s.id);
-    let items = db.getItems(sessionIds, {
+    const items = db.getItems(sessionIds, {
       category: classification.category || undefined,
       from: classification.from || undefined,
       to: classification.to || undefined,
     });
-    if (items.length === 0) return 'No items found.';
-
-    const grouped = {};
-    for (const item of items) {
-      if (!grouped[item.category]) grouped[item.category] = [];
-      grouped[item.category].push(item);
-    }
-    return Object.entries(grouped)
-      .map(([cat, catItems]) => {
-        const heading = `## ${cat.charAt(0).toUpperCase() + cat.slice(1)}s`;
-        const lines = catItems.map((i) => `- ${i.done ? `~~${i.text}~~` : i.text}`);
-        return [heading, ...lines].join('\n');
-      })
-      .join('\n\n');
+    return JSON.stringify({ __itemResult: true, items });
   }
 
   const prompt = ASK_TEMPLATE(sessionsContext, question);
@@ -117,8 +104,8 @@ ipcMain.handle("db:get-items", (_event, sessionIds) => {
   return db.getItems(sessionIds);
 });
 
-ipcMain.handle("db:mark-item-done", (_event, itemId) => {
-  db.markItemDone(itemId);
+ipcMain.handle("db:set-item-status", (_event, itemId, status) => {
+  db.setItemStatus(itemId, status);
 });
 
 ipcMain.handle("toggle-expand", () => {

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -78,7 +78,7 @@ ipcMain.handle("ask", async (_event, sessionsContext, question) => {
       from: classification.from || undefined,
       to: classification.to || undefined,
     });
-    return JSON.stringify({ __itemResult: true, items });
+    return JSON.stringify({ __itemResult: true, items, category: classification.category, from: classification.from, to: classification.to });
   }
 
   const prompt = ASK_TEMPLATE(sessionsContext, question);
@@ -104,8 +104,23 @@ ipcMain.handle("db:get-items", (_event, sessionIds) => {
   return db.getItems(sessionIds);
 });
 
+ipcMain.handle("db:query-items", (_event, { category, from, to } = {}) => {
+  const sessionIds = db.getAllSessions()
+    .filter((s) => s.session_type === 0)
+    .map((s) => s.id);
+  return db.getItems(sessionIds, { category, from, to });
+});
+
 ipcMain.handle("db:set-item-status", (_event, itemId, status) => {
   db.setItemStatus(itemId, status);
+});
+
+ipcMain.handle("db:save-ask-items", (_event, askSessionId, itemIds) => {
+  db.saveAskItems(askSessionId, itemIds);
+});
+
+ipcMain.handle("db:get-items-for-ask-session", (_event, askSessionId) => {
+  return db.getItemsForAskSession(askSessionId);
 });
 
 ipcMain.handle("toggle-expand", () => {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -13,5 +13,5 @@ contextBridge.exposeInMainWorld("electronAPI", {
   deleteSession: (sessionId) => ipcRenderer.invoke("db:delete-session", sessionId),
   extractItems: (sessionId, note) => ipcRenderer.invoke("extract-items", sessionId, note),
   getItems: (sessionIds) => ipcRenderer.invoke("db:get-items", sessionIds),
-  markItemDone: (itemId) => ipcRenderer.invoke("db:mark-item-done", itemId),
+  setItemStatus: (itemId, status) => ipcRenderer.invoke("db:set-item-status", itemId, status),
 });

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -13,5 +13,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
   deleteSession: (sessionId) => ipcRenderer.invoke("db:delete-session", sessionId),
   extractItems: (sessionId, note) => ipcRenderer.invoke("extract-items", sessionId, note),
   getItems: (sessionIds) => ipcRenderer.invoke("db:get-items", sessionIds),
+  queryItems: (filters) => ipcRenderer.invoke("db:query-items", filters),
   setItemStatus: (itemId, status) => ipcRenderer.invoke("db:set-item-status", itemId, status),
+  saveAskItems: (askSessionId, itemIds) => ipcRenderer.invoke("db:save-ask-items", askSessionId, itemIds),
+  getItemsForAskSession: (askSessionId) => ipcRenderer.invoke("db:get-items-for-ask-session", askSessionId),
 });

--- a/src/App.css
+++ b/src/App.css
@@ -606,6 +606,10 @@
 
 /* ── items section ── */
 .items-section {
+  margin-top: 0;
+}
+
+.items-section--with-summary {
   margin-top: 1.25rem;
   padding-top: 1rem;
   border-top: 1px solid rgba(0, 0, 0, 0.07);
@@ -625,19 +629,68 @@
 }
 
 .items-list {
-  list-style: disc;
-  padding-left: 1.25rem;
+  list-style: none;
+  padding: 0;
   margin: 0;
 }
 
 .items-list__item {
-  padding: 0.15rem 0;
+  display: flex;
+  flex-direction: column;
+  padding: 0.35rem 0;
   font-size: 0.85rem;
   color: #4a4a4a;
   line-height: 1.5;
 }
 
-.items-list__item--done {
+.items-list__item-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.items-list__item--done .items-list__item-text {
   text-decoration: line-through;
   color: rgba(0, 0, 0, 0.3);
+}
+
+.items-list__item-dismiss {
+  opacity: 0;
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  border: none;
+  background: transparent;
+  color: rgba(0, 0, 0, 0.35);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 0.15rem;
+  transition: opacity 0.12s ease, color 0.12s ease;
+}
+
+.items-list__item:hover .items-list__item-dismiss {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.items-list__item-dismiss:hover {
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.items-list__item-source {
+  margin-left: 1.75rem;
+  padding: 0;
+  border: none;
+  background: transparent;
+  font-size: 0.72rem;
+  font-family: inherit;
+  color: rgba(0, 0, 0, 0.35);
+  cursor: pointer;
+  text-align: left;
+}
+
+.items-list__item-source:hover {
+  color: rgba(0, 0, 0, 0.65);
+  text-decoration: underline;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,7 +28,7 @@ function App() {
   const [editingSessionSource, setEditingSessionSource] = useState(null)
 
   useEffect(() => {
-    window.electronAPI.getSessions().then((loaded) => {
+    window.electronAPI.getSessions().then(async (loaded) => {
       setSessions(loaded)
       const withSummary = {}
       loaded.forEach((s) => {
@@ -36,17 +36,24 @@ function App() {
       })
       setSummariesBySessionId(withSummary)
 
-      const sessionIds = loaded.map((s) => s.id)
-      if (sessionIds.length > 0) {
-        window.electronAPI.getItems(sessionIds).then((allItems) => {
-          const grouped = {}
-          for (const item of allItems) {
-            if (!grouped[item.session_id]) grouped[item.session_id] = []
-            grouped[item.session_id].push(item)
-          }
-          setItemsBySessionId(grouped)
-        })
+      const noteSessions = loaded.filter((s) => s.session_type === SessionType.NOTE)
+      const askSessions = loaded.filter((s) => s.session_type === SessionType.ASK)
+      const grouped = {}
+
+      if (noteSessions.length > 0) {
+        const allItems = await window.electronAPI.getItems(noteSessions.map((s) => s.id))
+        for (const item of allItems) {
+          if (!grouped[item.session_id]) grouped[item.session_id] = []
+          grouped[item.session_id].push(item)
+        }
       }
+
+      await Promise.all(askSessions.map(async (s) => {
+        const items = await window.electronAPI.getItemsForAskSession(s.id)
+        if (items.length > 0) grouped[s.id] = items
+      }))
+
+      setItemsBySessionId(grouped)
     })
   }, [])
 
@@ -183,7 +190,7 @@ function App() {
         const parsed = JSON.parse(result)
         if (parsed.__itemResult) {
           askItems = parsed.items
-          summary = ''
+          summary = null
         }
       } catch {
         // normal text answer
@@ -198,6 +205,7 @@ function App() {
       ])
       setSummariesBySessionId((prev) => ({ ...prev, [sessionId]: summary }))
       if (askItems) {
+        await window.electronAPI.saveAskItems(sessionId, askItems.map((i) => i.id))
         setItemsBySessionId((prev) => ({ ...prev, [sessionId]: askItems }))
       }
       setActiveSessionId(null)
@@ -439,6 +447,7 @@ function App() {
         </div>
         {expanded && (() => {
           const sessionIdToShow = selectedSessionId ?? currentSession?.id ?? null
+          const sessionToShow = sessions.find((s) => s.id === sessionIdToShow) ?? null
           const summaryToShow = sessionIdToShow ? summariesBySessionId[sessionIdToShow] : null
           const itemsToShow = sessionIdToShow ? (itemsBySessionId[sessionIdToShow] ?? []) : []
           return (
@@ -474,7 +483,13 @@ function App() {
                       <Markdown>{summaryToShow}</Markdown>
                     </div>
                   ) : !itemsToShow.length && (
-                    <p className="summary-empty">{sessionIdToShow ? 'No summary for this session yet' : 'Submit a note to see the brief'}</p>
+                    <p className="summary-empty">
+                      {!sessionIdToShow
+                        ? 'Submit a note to see the brief'
+                        : sessionToShow?.session_type === SessionType.ASK
+                          ? 'No answer for this question'
+                          : 'No summary for this session yet'}
+                    </p>
                   )}
                   {itemsToShow.length > 0 && (
                     <div className={`items-section${summaryToShow ? ' items-section--with-summary' : ''}`}>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -177,14 +177,29 @@ function App() {
 
       const result = await window.electronAPI.ask(sessionsContext, questionText)
 
+      let summary = result
+      let askItems = null
+      try {
+        const parsed = JSON.parse(result)
+        if (parsed.__itemResult) {
+          askItems = parsed.items
+          summary = ''
+        }
+      } catch {
+        // normal text answer
+      }
+
       // Create a new session for this Q&A
       await window.electronAPI.createSession(sessionId, sessionName, questionText, SessionType.ASK)
-      await window.electronAPI.updateSummary(sessionId, result)
+      await window.electronAPI.updateSummary(sessionId, summary)
       setSessions((prev) => [
         ...prev,
-        { id: sessionId, name: sessionName, note: questionText, summary: result, session_type: SessionType.ASK }
+        { id: sessionId, name: sessionName, note: questionText, summary, session_type: SessionType.ASK }
       ])
-      setSummariesBySessionId((prev) => ({ ...prev, [sessionId]: result }))
+      setSummariesBySessionId((prev) => ({ ...prev, [sessionId]: summary }))
+      if (askItems) {
+        setItemsBySessionId((prev) => ({ ...prev, [sessionId]: askItems }))
+      }
       setActiveSessionId(null)
       setSelectedSessionId(sessionId)
     } catch (err) {
@@ -452,28 +467,77 @@ function App() {
               <h3>Brief</h3>
               {loading ? (
                 <p className="summary-loading">Thinking...</p>
-              ) : summaryToShow ? (
-                <div className="summary-content">
-                  <Markdown>{summaryToShow}</Markdown>
-                </div>
-              ) : sessionIdToShow ? (
-                <p className="summary-empty">No summary for this session yet</p>
               ) : (
-                <p className="summary-empty">Submit a note to see the brief</p>
-              )}
-              {itemsToShow.length > 0 && (
-                <div className="items-section">
-                  <h3>Items</h3>
-                  {['issue', 'blocker', 'pending'].map((cat) => {
-                    const catItems = itemsToShow.filter((i) => i.category === cat)
+                <>
+                  {summaryToShow ? (
+                    <div className="summary-content">
+                      <Markdown>{summaryToShow}</Markdown>
+                    </div>
+                  ) : !itemsToShow.length && (
+                    <p className="summary-empty">{sessionIdToShow ? 'No summary for this session yet' : 'Submit a note to see the brief'}</p>
+                  )}
+                  {itemsToShow.length > 0 && (
+                    <div className={`items-section${summaryToShow ? ' items-section--with-summary' : ''}`}>
+                      {['issue', 'blocker', 'pending'].map((cat) => {
+                    const catItems = itemsToShow.filter((i) => i.category === cat && i.status !== -1)
                     if (!catItems.length) return null
                     return (
                       <div key={cat} className="items-group">
                         <p className="items-group__label">{cat}s</p>
                         <ul className="items-list">
                           {catItems.map((item) => (
-                            <li key={item.id} className={`items-list__item${item.done ? ' items-list__item--done' : ''}`}>
-                              {item.text}
+                            <li key={item.id} className={`items-list__item${item.status === 1 ? ' items-list__item--done' : ''}`}>
+                              <div className="items-list__item-row">
+                              <input
+                                type="checkbox"
+                                checked={item.status === 1}
+                                onChange={() => {
+                                  const newStatus = item.status === 1 ? 0 : 1
+                                  window.electronAPI.setItemStatus(item.id, newStatus)
+                                  setItemsBySessionId((prev) => {
+                                    const result = { ...prev }
+                                    const updateSession = (sid) => {
+                                      if (result[sid]) result[sid] = result[sid].map((i) => i.id === item.id ? { ...i, status: newStatus } : i)
+                                    }
+                                    updateSession(item.session_id)
+                                    if (sessionIdToShow !== item.session_id) updateSession(sessionIdToShow)
+                                    return result
+                                  })
+                                }}
+                              />
+                              <span className="items-list__item-text"><Markdown components={{ p: ({ children }) => <>{children}</> }}>{item.text}</Markdown></span>
+                              <button
+                                type="button"
+                                className="items-list__item-dismiss"
+                                onClick={() => {
+                                  window.electronAPI.setItemStatus(item.id, -1)
+                                  setItemsBySessionId((prev) => {
+                                    const result = { ...prev }
+                                    const updateSession = (sid) => {
+                                      if (result[sid]) result[sid] = result[sid].map((i) => i.id === item.id ? { ...i, status: -1 } : i)
+                                    }
+                                    updateSession(item.session_id)
+                                    if (sessionIdToShow !== item.session_id) updateSession(sessionIdToShow)
+                                    return result
+                                  })
+                                }}
+                                aria-label="Mark as invalid"
+                              >
+                                ×
+                              </button>
+                              </div>
+                              {item.session_id !== sessionIdToShow && (() => {
+                                const source = sessions.find((s) => s.id === item.session_id)
+                                return source ? (
+                                  <button
+                                    type="button"
+                                    className="items-list__item-source"
+                                    onClick={() => handleRestoreSession(item.session_id)}
+                                  >
+                                    {source.name}
+                                  </button>
+                                ) : null
+                              })()}
                             </li>
                           ))}
                         </ul>
@@ -481,6 +545,8 @@ function App() {
                     )
                   })}
                 </div>
+              )}
+                </>
               )}
             </div>
           )


### PR DESCRIPTION
  - Extracted items (issues, blockers, pendings) now render as an interactive
    list in the summary panel, replacing the raw JSON code block
  - Items support two actions: checkbox to toggle done, × button to mark invalid
  - Status is stored as an integer column (`0` pending, `1` done, `-1` invalid)
  - Ask queries that target items reuse the same items panel UI instead of
    returning formatted markdown — with checkboxes, × buttons, and a clickable
    source pill linking back to the originating session
  - Status updates from ask results sync back to the original session in state